### PR TITLE
Add configurable OpenAI API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Publish the configuration file:
 php artisan vendor:publish --tag=config --provider="OpenAI\\LaravelAgents\\AgentServiceProvider"
 ```
 
-Set your `OPENAI_API_KEY` in the environment file.
+Set your `OPENAI_API_KEY` in the environment file or edit `config/agents.php`.
 
 ## Usage
 

--- a/config/agents.php
+++ b/config/agents.php
@@ -1,6 +1,7 @@
 <?php
 
 return [
+    'api_key' => env('OPENAI_API_KEY'),
     /*
     |--------------------------------------------------------------------------
     | Default Agent Settings

--- a/src/AgentManager.php
+++ b/src/AgentManager.php
@@ -26,7 +26,7 @@ class AgentManager
     {
         $options = array_replace_recursive($this->config['default'] ?? [], $options);
 
-        $client = OpenAIClient::factory()->withApiKey(env('OPENAI_API_KEY'))->make();
+        $client = OpenAIClient::factory()->withApiKey($this->config['api_key'])->make();
 
         return new Agent($client, $options);
     }


### PR DESCRIPTION
## Summary
- add `api_key` setting to `config/agents.php`
- use configured API key when creating the client
- mention publishing config and setting API key in the README

## Testing
- `composer validate --no-check-all --strict`

------
https://chatgpt.com/codex/tasks/task_b_6850ae35192083278f12b1216b6e88dc