### PR TITLE
Add chat history support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,28 @@ $manager = app(AgentManager::class);
 $response = $manager->agent()->chat('Hello world');
 ```
 
+The returned `Agent` instance retains the conversation history, allowing for multi-turn chats:
+
+```php
+$agent = $manager->agent();
+
+// First user message
+$agent->chat('Hello');
+
+// Follow-up message uses previous context
+$reply = $agent->chat('What did I just say?');
+```
+
+You can optionally provide a system prompt when constructing the agent:
+
+```php
+use OpenAI\LaravelAgents\Agent;
+use OpenAI\Client as OpenAIClient;
+
+$client = OpenAIClient::factory()->withApiKey(env('OPENAI_API_KEY'))->make();
+$agent = new Agent($client, [], 'You are a helpful assistant.');
+```
+
 ## Configuration
 
 The `config/agents.php` file allows you to customize the default model and parameters used when interacting with OpenAI.


### PR DESCRIPTION
## Summary
- track chat messages in Agent
- allow optional system prompt in constructor
- include previous messages when chatting
- document multi-turn conversation in README

## Testing
- `composer validate --no-check-all` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6850b23f02e48327a6424cdcc1fde389