### PR TITLE
Add PHPUnit tests and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.3
+      - name: Run PHPUnit
+        run: |
+          php -v
+          php -m
+          phpunit --version || true
+          sudo apt-get update
+          sudo apt-get install -y phpunit
+          phpunit --configuration tests/phpunit.xml

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor/
 composer.lock
+tests/.phpunit.result.cache

--- a/tests/AgentChatTest.php
+++ b/tests/AgentChatTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use OpenAI\Contracts\ClientContract;
+use OpenAI\Contracts\ChatContract;
+use OpenAI\LaravelAgents\Agent;
+use PHPUnit\Framework\TestCase;
+
+class AgentChatTest extends TestCase
+{
+    public function test_chat_returns_reply_from_client()
+    {
+        $chatMock = $this->createMock(ChatContract::class);
+        $chatMock->expects($this->once())
+            ->method('create')
+            ->with($this->callback(function (array $params) {
+                return isset($params['messages'][0]) &&
+                       $params['messages'][0]['role'] === 'user' &&
+                       $params['messages'][0]['content'] === 'Hello';
+            }))
+            ->willReturn([
+                'choices' => [
+                    ['message' => ['content' => 'Hi there']]
+                ]
+            ]);
+
+        $clientMock = $this->createMock(ClientContract::class);
+        $clientMock->expects($this->once())
+            ->method('chat')
+            ->willReturn($chatMock);
+
+        $agent = new Agent($clientMock);
+
+        $reply = $agent->chat('Hello');
+
+        $this->assertSame('Hi there', $reply);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,15 @@
+<?php
+// Minimal stubs of OpenAI client interfaces for testing without the package.
+namespace OpenAI\Contracts {
+    interface ChatContract {
+        public function create(array $parameters);
+    }
+
+    interface ClientContract {
+        public function chat(): ChatContract;
+    }
+}
+
+namespace {
+    require_once __DIR__ . '/../src/Agent.php';
+}

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="bootstrap.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="Default">
+            <directory suffix="Test.php">.</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>


### PR DESCRIPTION
## Summary
- add PHPUnit bootstrap and configuration
- implement a test for `Agent::chat()` using mock client contracts
- ignore PHPUnit result cache
- run tests in GitHub Actions

## Testing
- `phpunit --configuration tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_b_6850b69a882c8327b6cea1af612415c9