### PR TITLE
Add runner loop and CLI options

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ Send a message to the default agent:
 php artisan agent:chat "Hello"
 ```
 
+You can control the number of turns or provide a system prompt using options:
+
+```bash
+php artisan agent:chat "Hello" --system="You are helpful" --max-turns=3
+```
+
 You can also resolve the `AgentManager` service from the container to create agents programmatically.
 
 ```php
@@ -55,6 +61,18 @@ use OpenAI\Client as OpenAIClient;
 
 $client = OpenAIClient::factory()->withApiKey(env('OPENAI_API_KEY'))->make();
 $agent = new Agent($client, [], 'You are a helpful assistant.');
+```
+
+For more advanced scenarios you can use the `Runner` class which loops until the
+agent returns a final response or a turn limit is reached. Tools and basic handoffs
+can be registered on the runner:
+
+```php
+use OpenAI\LaravelAgents\Runner;
+
+$runner = new Runner($agent, maxTurns: 3);
+$runner->registerTool('echo', fn($text) => $text);
+$reply = $runner->run('Start');
 ```
 
 ## Configuration

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -31,6 +31,14 @@ class Agent
     }
 
     /**
+     * Get the underlying OpenAI client instance.
+     */
+    public function getClient(): ClientContract
+    {
+        return $this->client;
+    }
+
+    /**
      * Send a message to the agent and get a response.
      */
     public function chat(string $message): string

--- a/src/AgentManager.php
+++ b/src/AgentManager.php
@@ -22,12 +22,12 @@ class AgentManager
     /**
      * Create a new agent instance.
      */
-    public function agent(array $options = []): Agent
+    public function agent(array $options = [], ?string $systemPrompt = null): Agent
     {
         $options = array_replace_recursive($this->config['default'] ?? [], $options);
 
         $client = OpenAIClient::factory()->withApiKey($this->config['api_key'])->make();
 
-        return new Agent($client, $options);
+        return new Agent($client, $options, $systemPrompt);
     }
 }

--- a/src/Commands/ChatAgent.php
+++ b/src/Commands/ChatAgent.php
@@ -7,16 +7,34 @@ use OpenAI\LaravelAgents\AgentManager;
 
 class ChatAgent extends Command
 {
-    protected $signature = 'agent:chat {message}';
+    protected $signature = 'agent:chat {message}'
+        . ' {--system=}'
+        . ' {--max-turns=5}'
+        . ' {--trace}';
 
     protected $description = 'Send a prompt to the OpenAI agent and output the response.';
 
     public function handle(AgentManager $manager): int
     {
         $message = $this->argument('message');
-        $agent = $manager->agent();
+        $system = $this->option('system');
+        $max = (int) $this->option('max-turns');
+        $trace = $this->option('trace');
 
-        $response = $agent->chat($message);
+        $agent = $manager->agent([], $system);
+
+        $tracer = null;
+        if ($trace) {
+            $tracer = function (array $data) {
+                $this->info('Turn ' . $data['turn']);
+                $this->line('> ' . $data['input']);
+                $this->line('< ' . $data['output']);
+            };
+        }
+
+        $runner = new \OpenAI\LaravelAgents\Runner($agent, $max, $tracer);
+
+        $response = $runner->run($message);
 
         $this->line($response);
 

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace OpenAI\LaravelAgents;
+
+class Runner
+{
+    protected Agent $agent;
+    protected int $maxTurns;
+    protected array $tools = [];
+    protected array $inputGuards = [];
+    protected array $outputGuards = [];
+    protected $tracer;
+
+    public function __construct(Agent $agent, int $maxTurns = 5, ?callable $tracer = null)
+    {
+        $this->agent = $agent;
+        $this->maxTurns = $maxTurns;
+        $this->tracer = $tracer;
+    }
+
+    public function registerTool(string $name, callable $callback): void
+    {
+        $this->tools[$name] = $callback;
+    }
+
+    public function addInputGuard(callable $guard): void
+    {
+        $this->inputGuards[] = $guard;
+    }
+
+    public function addOutputGuard(callable $guard): void
+    {
+        $this->outputGuards[] = $guard;
+    }
+
+    public function run(string $message): string
+    {
+        $turn = 0;
+        $input = $message;
+        $response = '';
+        while ($turn < $this->maxTurns) {
+            foreach ($this->inputGuards as $guard) {
+                $input = $guard($input);
+            }
+
+            $response = $this->agent->chat($input);
+
+            foreach ($this->outputGuards as $guard) {
+                $response = $guard($response);
+            }
+
+            if ($this->tracer) {
+                ($this->tracer)([
+                    'turn' => $turn + 1,
+                    'input' => $input,
+                    'output' => $response,
+                ]);
+            }
+
+            if (preg_match('/\[\[tool:(\w+)(?:\s+([^\]]+))?\]\]/', $response, $m)) {
+                $name = $m[1];
+                $arg = $m[2] ?? '';
+                if (isset($this->tools[$name])) {
+                    $input = ($this->tools[$name])($arg);
+                    $turn++;
+                    continue;
+                }
+            }
+
+            if (preg_match('/\[\[handoff:(.+)\]\]/', $response, $m)) {
+                $prompt = $m[1];
+                $this->agent = new Agent($this->agent->getClient(), [], $prompt);
+                $input = '';
+                $turn++;
+                continue;
+            }
+
+            break;
+        }
+
+        return $response;
+    }
+}

--- a/tests/RunnerTest.php
+++ b/tests/RunnerTest.php
@@ -1,0 +1,50 @@
+<?php
+
+use OpenAI\Contracts\ClientContract;
+use OpenAI\Contracts\ChatContract;
+use OpenAI\LaravelAgents\Agent;
+use OpenAI\LaravelAgents\Runner;
+use PHPUnit\Framework\TestCase;
+
+class RunnerTest extends TestCase
+{
+    public function test_runner_calls_registered_tool()
+    {
+        $chat = $this->createMock(ChatContract::class);
+        $chat->expects($this->exactly(2))
+            ->method('create')
+            ->willReturnOnConsecutiveCalls(
+                ['choices' => [['message' => ['content' => '[[tool:echo hi]]']]]],
+                ['choices' => [['message' => ['content' => 'Done']]]]
+            );
+
+        $client = $this->createMock(ClientContract::class);
+        $client->method('chat')->willReturn($chat);
+
+        $agent = new Agent($client);
+        $runner = new Runner($agent, 3);
+        $runner->registerTool('echo', fn($arg) => $arg);
+
+        $result = $runner->run('start');
+
+        $this->assertSame('Done', $result);
+    }
+
+    public function test_runner_respects_max_turns()
+    {
+        $chat = $this->createMock(ChatContract::class);
+        $chat->expects($this->once())
+            ->method('create')
+            ->willReturn(['choices' => [['message' => ['content' => '[[tool:unknown]]']]]]);
+
+        $client = $this->createMock(ClientContract::class);
+        $client->method('chat')->willReturn($chat);
+
+        $agent = new Agent($client);
+        $runner = new Runner($agent, 1);
+
+        $result = $runner->run('start');
+
+        $this->assertSame('[[tool:unknown]]', $result);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -12,4 +12,5 @@ namespace OpenAI\Contracts {
 
 namespace {
     require_once __DIR__ . '/../src/Agent.php';
+    require_once __DIR__ . '/../src/Runner.php';
 }


### PR DESCRIPTION
## Summary
- add Runner with iteration loop, tool calls and handoffs
- expose underlying client from Agent and allow system prompt in AgentManager
- update chat command with new options and tracing
- document runner usage in README
- add unit tests for Runner

## Testing
- `./vendor/bin/phpunit -c tests/phpunit.xml` *(fails: No such file or directory)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6852d05232c88327b59655b5cebfa752