### PR TITLE
Add tracing service integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,27 @@ $runner->registerTool('echo', fn($text) => $text);
 $reply = $runner->run('Start');
 ```
 
+### Tracing
+
+The package includes a simple tracing system that lets you observe each turn
+of a `Runner` execution. Enable tracing in `config/agents.php` and register one
+or more processors to handle trace records:
+
+```php
+return [
+    // ...
+    'tracing' => [
+        'enabled' => true,
+        'processors' => [
+            fn(array $record) => logger()->info('agent trace', $record),
+        ],
+    ],
+];
+```
+
+When enabled, each call to `Runner::run()` will emit start and end span events
+as well as per-turn events containing the input and output.
+
 ### Guardrails
 
 Guardrails let you validate input and output during a run. They can transform
@@ -105,7 +126,7 @@ $runner->addOutputGuardrail(new class extends OutputGuardrail {
 
 ## Configuration
 
-The `config/agents.php` file allows you to customize the default model and parameters used when interacting with OpenAI.
+The `config/agents.php` file allows you to customize the default model and parameters used when interacting with OpenAI. It also contains options to enable tracing and provide custom processors for handling trace data.
 
 ## License
 

--- a/config/agents.php
+++ b/config/agents.php
@@ -17,4 +17,11 @@ return [
         'temperature' => env('OPENAI_TEMPERATURE', 0.7),
         'top_p' => env('OPENAI_TOP_P', 1.0),
     ],
+
+    'tracing' => [
+        'enabled' => env('AGENTS_TRACING', false),
+        'processors' => [
+            // callable list of trace processors
+        ],
+    ],
 ];

--- a/src/AgentServiceProvider.php
+++ b/src/AgentServiceProvider.php
@@ -3,6 +3,7 @@
 namespace OpenAI\LaravelAgents;
 
 use Illuminate\Support\ServiceProvider;
+use OpenAI\LaravelAgents\Tracing\Tracing;
 
 class AgentServiceProvider extends ServiceProvider
 {
@@ -31,6 +32,14 @@ class AgentServiceProvider extends ServiceProvider
 
         $this->app->singleton(AgentManager::class, function ($app) {
             return new AgentManager($app['config']['agents']);
+        });
+
+        $this->app->singleton(Tracing::class, function ($app) {
+            $config = $app['config']['agents.tracing'];
+            if (!($config['enabled'] ?? false)) {
+                return new Tracing();
+            }
+            return new Tracing($config['processors'] ?? []);
         });
     }
 }

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -5,6 +5,7 @@ namespace OpenAI\LaravelAgents;
 use OpenAI\LaravelAgents\Guardrails\GuardrailException;
 use OpenAI\LaravelAgents\Guardrails\InputGuardrail;
 use OpenAI\LaravelAgents\Guardrails\OutputGuardrail;
+use OpenAI\LaravelAgents\Tracing\Tracing;
 
 class Runner
 {
@@ -13,9 +14,9 @@ class Runner
     protected array $tools = [];
     protected array $inputGuardrails = [];
     protected array $outputGuardrails = [];
-    protected $tracer;
+    protected ?Tracing $tracer = null;
 
-    public function __construct(Agent $agent, int $maxTurns = 5, ?callable $tracer = null)
+    public function __construct(Agent $agent, int $maxTurns = 5, ?Tracing $tracer = null)
     {
         $this->agent = $agent;
         $this->maxTurns = $maxTurns;
@@ -39,6 +40,7 @@ class Runner
 
     public function run(string $message): string
     {
+        $spanId = $this->tracer?->startSpan('runner', ['max_turns' => $this->maxTurns]);
         $turn = 0;
         $input = $message;
         $response = '';
@@ -47,12 +49,10 @@ class Runner
                 try {
                     $input = $guard->validate($input);
                 } catch (GuardrailException $e) {
-                    if ($this->tracer) {
-                        ($this->tracer)([
-                            'turn' => $turn + 1,
-                            'error' => $e->getMessage(),
-                        ]);
-                    }
+                    $this->tracer?->recordEvent($spanId, [
+                        'turn' => $turn + 1,
+                        'error' => $e->getMessage(),
+                    ]);
                     throw $e;
                 }
             }
@@ -63,23 +63,19 @@ class Runner
                 try {
                     $response = $guard->validate($response);
                 } catch (GuardrailException $e) {
-                    if ($this->tracer) {
-                        ($this->tracer)([
-                            'turn' => $turn + 1,
-                            'error' => $e->getMessage(),
-                        ]);
-                    }
+                    $this->tracer?->recordEvent($spanId, [
+                        'turn' => $turn + 1,
+                        'error' => $e->getMessage(),
+                    ]);
                     throw $e;
                 }
             }
 
-            if ($this->tracer) {
-                ($this->tracer)([
-                    'turn' => $turn + 1,
-                    'input' => $input,
-                    'output' => $response,
-                ]);
-            }
+            $this->tracer?->recordEvent($spanId, [
+                'turn' => $turn + 1,
+                'input' => $input,
+                'output' => $response,
+            ]);
 
             if (preg_match('/\[\[tool:(\w+)(?:\s+([^\]]+))?\]\]/', $response, $m)) {
                 $name = $m[1];
@@ -102,6 +98,7 @@ class Runner
             break;
         }
 
+        $this->tracer?->endSpan($spanId);
         return $response;
     }
 }

--- a/src/Tracing/Tracing.php
+++ b/src/Tracing/Tracing.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace OpenAI\LaravelAgents\Tracing;
+
+class Tracing
+{
+    /**
+     * @var array<int, callable>
+     */
+    protected array $processors = [];
+
+    public function __construct(array $processors = [])
+    {
+        foreach ($processors as $processor) {
+            if (is_callable($processor)) {
+                $this->processors[] = $processor;
+            }
+        }
+    }
+
+    public function startSpan(string $name, array $attributes = []): string
+    {
+        $id = uniqid('span_', true);
+        $this->dispatch(['type' => 'start_span', 'id' => $id, 'name' => $name, 'attributes' => $attributes]);
+        return $id;
+    }
+
+    public function endSpan(string $id): void
+    {
+        $this->dispatch(['type' => 'end_span', 'id' => $id]);
+    }
+
+    public function recordEvent(string $id, array $data): void
+    {
+        $this->dispatch(['type' => 'event', 'id' => $id] + $data);
+    }
+
+    protected function dispatch(array $record): void
+    {
+        foreach ($this->processors as $processor) {
+            $processor($record);
+        }
+    }
+}

--- a/tests/TracingTest.php
+++ b/tests/TracingTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use OpenAI\Contracts\ChatContract;
+use OpenAI\Contracts\ClientContract;
+use OpenAI\LaravelAgents\Agent;
+use OpenAI\LaravelAgents\Runner;
+use OpenAI\LaravelAgents\Tracing\Tracing;
+use PHPUnit\Framework\TestCase;
+
+class TracingTest extends TestCase
+{
+    public function test_runner_emits_tracing_events()
+    {
+        $chat = $this->createMock(ChatContract::class);
+        $chat->expects($this->once())
+            ->method('create')
+            ->willReturn([
+                'choices' => [
+                    ['message' => ['content' => 'Done']]
+                ]
+            ]);
+
+        $client = $this->createMock(ClientContract::class);
+        $client->method('chat')->willReturn($chat);
+
+        $records = [];
+        $tracing = new Tracing([
+            function (array $record) use (&$records) { $records[] = $record; }
+        ]);
+
+        $agent = new Agent($client);
+        $runner = new Runner($agent, 3, $tracing);
+
+        $result = $runner->run('start');
+
+        $this->assertSame('Done', $result);
+        $this->assertSame('start_span', $records[0]['type']);
+        $this->assertSame('event', $records[1]['type']);
+        $this->assertSame('end_span', $records[count($records)-1]['type']);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -18,4 +18,5 @@ namespace {
     require_once __DIR__ . '/../src/Guardrails/OutputGuardrailException.php';
     require_once __DIR__ . '/../src/Guardrails/InputGuardrail.php';
     require_once __DIR__ . '/../src/Guardrails/OutputGuardrail.php';
+    require_once __DIR__ . '/../src/Tracing/Tracing.php';
 }


### PR DESCRIPTION
## Summary
- add a Tracing service with span and event helpers
- integrate Runner with Tracing service
- register Tracing in service provider
- expose tracing settings in configuration
- document tracing usage and setup
- add tests for tracing

## Testing
- `phpunit -c tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_b_6852dacdf0308327832eedff09f7bd8c