### PR TITLE
Add structured output support and typed tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,24 @@ $runner->registerTool('echo', fn($text) => $text);
 $reply = $runner->run('Start');
 ```
 
+The runner can request structured JSON output by providing an output schema:
+
+```php
+$schema = ['required' => ['done']];
+$runner = new Runner($agent, maxTurns: 3, tracer: null, outputType: $schema);
+$result = $runner->run('Start'); // returns an associative array
+```
+
+Tools may also be defined with JSON schemas for OpenAI function calling:
+
+```php
+$runner->registerFunctionTool('echo', fn(array $args) => $args['text'], [
+    'type' => 'object',
+    'properties' => ['text' => ['type' => 'string']],
+    'required' => ['text'],
+]);
+```
+
 ### Tracing
 
 The package includes a simple tracing system that lets you observe each turn

--- a/tests/RunnerTest.php
+++ b/tests/RunnerTest.php
@@ -47,4 +47,52 @@ class RunnerTest extends TestCase
 
         $this->assertSame('[[tool:unknown]]', $result);
     }
+
+    public function test_runner_waits_for_structured_output()
+    {
+        $chat = $this->createMock(ChatContract::class);
+        $chat->expects($this->exactly(2))
+            ->method('create')
+            ->willReturnOnConsecutiveCalls(
+                ['choices' => [['message' => ['content' => 'not json']]]],
+                ['choices' => [['message' => ['content' => '{"done":true}']]]]
+            );
+
+        $client = $this->createMock(ClientContract::class);
+        $client->method('chat')->willReturn($chat);
+
+        $schema = ['required' => ['done']];
+        $agent = new Agent($client, [], null, $schema);
+        $runner = new Runner($agent, 3, null, $schema);
+
+        $result = $runner->run('start');
+
+        $this->assertSame(['done' => true], $result);
+    }
+
+    public function test_runner_calls_function_tool()
+    {
+        $chat = $this->createMock(ChatContract::class);
+        $chat->expects($this->exactly(2))
+            ->method('create')
+            ->withConsecutive(
+                [$this->callback(fn($p) => isset($p['tools']) && $p['tools'][0]['function']['name'] === 'echo')],
+                [$this->anything()]
+            )
+            ->willReturnOnConsecutiveCalls(
+                ['choices' => [['message' => ['content' => '[[tool:echo "hi"]]']]]],
+                ['choices' => [['message' => ['content' => 'Done']]]]
+            );
+
+        $client = $this->createMock(ClientContract::class);
+        $client->method('chat')->willReturn($chat);
+
+        $agent = new Agent($client);
+        $runner = new Runner($agent, 3);
+        $runner->registerFunctionTool('echo', fn($arg) => $arg, ['type' => 'object']);
+
+        $result = $runner->run('start');
+
+        $this->assertSame('Done', $result);
+    }
 }


### PR DESCRIPTION
## Summary
- support optional output type in `Agent` and `Runner`
- keep tool schemas and expose `registerFunctionTool`
- detect final JSON output in `Runner`
- add unit tests for structured output and typed tools
- document structured output and function tools in README

## Testing
- `composer install` *(fails: command not found)*
- `./vendor/bin/phpunit --configuration tests/phpunit.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6853022afd3c83279b6a899410b63c65