### PR TITLE
Add voice, handoffs, tracing and async features

### DIFF
--- a/src/Agent.php
+++ b/src/Agent.php
@@ -3,6 +3,7 @@
 namespace OpenAI\LaravelAgents;
 
 use OpenAI\Contracts\ClientContract;
+use OpenAI\Contracts\AudioContract;
 
 class Agent
 {
@@ -85,5 +86,22 @@ class Agent
         }
 
         return $reply;
+    }
+
+    /**
+     * Convert the provided text to speech using OpenAI's API.
+     */
+    public function speak(string $text, array $options = []): string
+    {
+        $params = [
+            'model' => $options['model'] ?? 'tts-1',
+            'voice' => $options['voice'] ?? 'alloy',
+            'input' => $text,
+            'response_format' => $options['response_format'] ?? 'mp3',
+        ];
+
+        $response = $this->client->audio()->speech($params);
+
+        return $response;
     }
 }

--- a/src/Tracing/HttpProcessor.php
+++ b/src/Tracing/HttpProcessor.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace OpenAI\LaravelAgents\Tracing;
+
+use Symfony\Component\HttpClient\HttpClient;
+
+class HttpProcessor
+{
+    protected string $url;
+
+    public function __construct(string $url)
+    {
+        $this->url = $url;
+    }
+
+    public function __invoke(array $record): void
+    {
+        $client = HttpClient::create();
+        $client->request('POST', $this->url, ['json' => $record]);
+    }
+}

--- a/tests/AgentChatTest.php
+++ b/tests/AgentChatTest.php
@@ -2,6 +2,7 @@
 
 use OpenAI\Contracts\ClientContract;
 use OpenAI\Contracts\ChatContract;
+use OpenAI\Contracts\AudioContract;
 use OpenAI\LaravelAgents\Agent;
 use PHPUnit\Framework\TestCase;
 
@@ -33,5 +34,26 @@ class AgentChatTest extends TestCase
         $reply = $agent->chat('Hello');
 
         $this->assertSame('Hi there', $reply);
+    }
+
+    public function test_speak_calls_audio_api()
+    {
+        $audioMock = $this->createMock(AudioContract::class);
+        $audioMock->expects($this->once())
+            ->method('speech')
+            ->with($this->callback(fn(array $p) => $p['input'] === 'Hello'))
+            ->willReturn('audio-data');
+
+        $clientMock = $this->createMock(ClientContract::class);
+        $clientMock->method('chat')->willReturn($this->createMock(ChatContract::class));
+        $clientMock->expects($this->once())
+            ->method('audio')
+            ->willReturn($audioMock);
+
+        $agent = new Agent($clientMock);
+
+        $result = $agent->speak('Hello');
+
+        $this->assertSame('audio-data', $result);
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,8 +5,13 @@ namespace OpenAI\Contracts {
         public function create(array $parameters);
     }
 
+    interface AudioContract {
+        public function speech(array $parameters);
+    }
+
     interface ClientContract {
         public function chat(): ChatContract;
+        public function audio(): AudioContract;
     }
 }
 


### PR DESCRIPTION
## Summary
- implement `Agent::speak` for text-to-speech
- add automatic schema generation and named agent handoffs in `Runner`
- support async execution with `Runner::runAsync`
- provide HTTP tracing processor
- update tests and docs

## Testing
- `phpunit --configuration tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_b_68530598f248832782f75026a2e3a760