### PR TITLE
Update CI PHP version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.3
+          php-version: 8.4
       - name: Run PHPUnit
         run: |
           php -v


### PR DESCRIPTION
## Summary
- bump PHP version in CI from 8.3 to 8.4

## Testing
- `vendor/bin/phpunit --configuration tests/phpunit.xml` *(fails: `vendor/bin/phpunit: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_b_6853362a9264832781bff74ec8df1465