### PR TITLE
Add strict types

### DIFF
--- a/src/Agent.php
+++ b/src/Agent.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace OpenAI\LaravelAgents;
 

--- a/src/AgentManager.php
+++ b/src/AgentManager.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace OpenAI\LaravelAgents;
 

--- a/src/AgentServiceProvider.php
+++ b/src/AgentServiceProvider.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace OpenAI\LaravelAgents;
 

--- a/src/Commands/ChatAgent.php
+++ b/src/Commands/ChatAgent.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace OpenAI\LaravelAgents\Commands;
 

--- a/src/Guardrails/GuardrailException.php
+++ b/src/Guardrails/GuardrailException.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace OpenAI\LaravelAgents\Guardrails;
 

--- a/src/Guardrails/InputGuardrail.php
+++ b/src/Guardrails/InputGuardrail.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace OpenAI\LaravelAgents\Guardrails;
 

--- a/src/Guardrails/InputGuardrailException.php
+++ b/src/Guardrails/InputGuardrailException.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace OpenAI\LaravelAgents\Guardrails;
 

--- a/src/Guardrails/OutputGuardrail.php
+++ b/src/Guardrails/OutputGuardrail.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace OpenAI\LaravelAgents\Guardrails;
 

--- a/src/Guardrails/OutputGuardrailException.php
+++ b/src/Guardrails/OutputGuardrailException.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace OpenAI\LaravelAgents\Guardrails;
 

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace OpenAI\LaravelAgents;
 

--- a/src/Tracing/HttpProcessor.php
+++ b/src/Tracing/HttpProcessor.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace OpenAI\LaravelAgents\Tracing;
 

--- a/src/Tracing/Tracing.php
+++ b/src/Tracing/Tracing.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace OpenAI\LaravelAgents\Tracing;
 


### PR DESCRIPTION
## Summary
- insert `declare(strict_types=1);` at the top of every PHP file in `src/`

## Testing
- `vendor/bin/phpunit --configuration tests/phpunit.xml` *(fails: vendor not found)*

------
https://chatgpt.com/codex/tasks/task_b_6853362ed7f083278bc90987731f2c56