### PR TITLE
Add docblock to Runner run method

### DIFF
--- a/src/Runner.php
+++ b/src/Runner.php
@@ -77,6 +77,7 @@ class Runner
         $this->outputGuardrails[] = $guard;
     }
 
+    /** @return string|array */
     public function run(string $message): string|array
     {
         $spanId = $this->tracer?->startSpan('runner', ['max_turns' => $this->maxTurns]);


### PR DESCRIPTION
## Summary
- add missing `@return string|array` docblock for `Runner::run`

## Testing
- `phpunit -c tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_b_68533633b1cc832783ed4a8528f51b82