### PR TITLE
Add AgentManager tests for option merging

### DIFF
--- a/tests/AgentManagerTest.php
+++ b/tests/AgentManagerTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace OpenAI {
+    class Client {
+        public static $factory;
+        public static function factory() {
+            return static::$factory;
+        }
+    }
+}
+
+namespace {
+
+use OpenAI\Contracts\ChatContract;
+use OpenAI\Contracts\AudioContract;
+use OpenAI\Contracts\ClientContract;
+use OpenAI\LaravelAgents\AgentManager;
+use PHPUnit\Framework\TestCase;
+
+class AgentManagerTest extends TestCase
+{
+    public function test_agent_merges_default_config()
+    {
+        $chat = $this->createMock(ChatContract::class);
+        $chat->expects($this->once())
+            ->method('create')
+            ->with($this->callback(function(array $p) {
+                return $p['model'] === 'gpt-4' &&
+                       $p['temperature'] === 0.5 &&
+                       $p['top_p'] === 0.9;
+            }))
+            ->willReturn(['choices' => [['message' => ['content' => 'ok']]]]);
+
+        $client = new class($chat) implements ClientContract {
+            private $chat;
+            public function __construct($chat) { $this->chat = $chat; }
+            public function chat(): ChatContract { return $this->chat; }
+            public function audio(): AudioContract { throw new \Exception('audio'); }
+        };
+
+        \OpenAI\Client::$factory = new class($client) {
+            private $client;
+            public function __construct($client) { $this->client = $client; }
+            public function withApiKey($key) { return $this; }
+            public function make() { return $this->client; }
+        };
+
+        $config = [
+            'api_key' => 'key',
+            'default' => [
+                'model' => 'gpt-4',
+                'temperature' => 0.1,
+                'top_p' => 0.9,
+            ],
+        ];
+
+        $manager = new AgentManager($config);
+        $agent = $manager->agent(['temperature' => 0.5]);
+        $reply = $agent->chat('hello');
+
+        $this->assertSame('ok', $reply);
+    }
+
+    public function test_agent_overrides_multiple_options()
+    {
+        $chat = $this->createMock(ChatContract::class);
+        $chat->expects($this->once())
+            ->method('create')
+            ->with($this->callback(function(array $p) {
+                return $p['model'] === 'gpt-3.5' &&
+                       $p['temperature'] === 0.1 &&
+                       $p['top_p'] === 0.8;
+            }))
+            ->willReturn(['choices' => [['message' => ['content' => 'ok']]]]);
+
+        $client = new class($chat) implements ClientContract {
+            private $chat;
+            public function __construct($chat) { $this->chat = $chat; }
+            public function chat(): ChatContract { return $this->chat; }
+            public function audio(): AudioContract { throw new \Exception('audio'); }
+        };
+
+        \OpenAI\Client::$factory = new class($client) {
+            private $client;
+            public function __construct($client) { $this->client = $client; }
+            public function withApiKey($key) { return $this; }
+            public function make() { return $this->client; }
+        };
+
+        $config = [
+            'api_key' => 'key',
+            'default' => [
+                'model' => 'gpt-4',
+                'temperature' => 0.1,
+                'top_p' => 0.9,
+            ],
+        ];
+
+        $manager = new AgentManager($config);
+        $agent = $manager->agent([
+            'model' => 'gpt-3.5',
+            'top_p' => 0.8,
+        ]);
+        $reply = $agent->chat('hello');
+
+        $this->assertSame('ok', $reply);
+    }
+}
+
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -17,6 +17,7 @@ namespace OpenAI\Contracts {
 
 namespace {
     require_once __DIR__ . '/../src/Agent.php';
+    require_once __DIR__ . '/../src/AgentManager.php';
     require_once __DIR__ . '/../src/Runner.php';
     require_once __DIR__ . '/../src/Guardrails/GuardrailException.php';
     require_once __DIR__ . '/../src/Guardrails/InputGuardrailException.php';


### PR DESCRIPTION
## Summary
- add tests for `AgentManager::agent` combining defaults with options
- include `AgentManager.php` in test bootstrap

## Testing
- `phpunit --configuration tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_b_68533639f2748327ba447ced854d64fb