### PR TITLE
Add streaming and voice features

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,24 @@ $fiber->start();
 $result = $fiber->getReturn();
 ```
 
+You can also stream results as they're generated:
+
+```php
+foreach ($runner->runStreamed('Hello') as $chunk) {
+    echo $chunk;
+}
+```
+
+### Voice pipeline
+
+Use the `VoicePipeline` class to handle audio transcription and text-to-speech in one step:
+
+```php
+$pipeline = new VoicePipeline($client, $agent);
+$audio = $pipeline->run('input.wav');
+file_put_contents('reply.mp3', $audio);
+```
+
 ### Tracing
 
 The package includes a simple tracing system that lets you observe each turn

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -28,11 +28,19 @@ class Agent
      */
     protected $outputType = null;
 
-    public function __construct(ClientContract $client, array $options = [], ?string $systemPrompt = null, $outputType = null)
+    /**
+     * Optional user provided context for dependency injection.
+     */
+    protected array $context = [];
+
+    protected ?string $systemPrompt = null;
+    public function __construct(ClientContract $client, array $options = [], ?string $systemPrompt = null, $outputType = null, array $context = [])
     {
         $this->client = $client;
         $this->options = $options;
         $this->outputType = $outputType;
+        $this->systemPrompt = $systemPrompt;
+        $this->context = $context;
         if ($systemPrompt !== null) {
             $this->messages[] = ['role' => 'system', 'content' => $systemPrompt];
         }
@@ -44,6 +52,26 @@ class Agent
     public function getClient(): ClientContract
     {
         return $this->client;
+    }
+
+    /**
+     * Get the context array.
+     */
+    public function getContext(): array
+    {
+        return $this->context;
+    }
+
+    /**
+     * Clone the current agent optionally overriding options or system prompt.
+     */
+    public function clone(array $options = [], ?string $systemPrompt = null, array $context = null): self
+    {
+        $options = array_replace_recursive($this->options, $options);
+        $systemPrompt = $systemPrompt ?? $this->systemPrompt;
+        $context = $context ?? $this->context;
+
+        return new self($this->client, $options, $systemPrompt, $this->outputType, $context);
     }
 
     /**
@@ -87,6 +115,51 @@ class Agent
         }
 
         return $reply;
+    }
+
+    /**
+     * Send a message and return a streaming iterator of chunks.
+     *
+     * @return iterable<int, string>
+     */
+    public function chatStreamed(string $message, array $toolDefinitions = [], $outputType = null): iterable
+    {
+        $this->messages[] = ['role' => 'user', 'content' => $message];
+
+        $params = [
+            'model' => $this->options['model'] ?? 'gpt-4o',
+            'messages' => $this->messages,
+            'temperature' => $this->options['temperature'] ?? null,
+            'top_p' => $this->options['top_p'] ?? null,
+            'stream' => true,
+        ];
+
+        if (!empty($toolDefinitions)) {
+            $params['tools'] = array_map(function (array $tool) {
+                return [
+                    'type' => 'function',
+                    'function' => [
+                        'name' => $tool['name'],
+                        'parameters' => $tool['schema'],
+                    ],
+                ];
+            }, $toolDefinitions);
+            $params['tool_choice'] = 'auto';
+        }
+
+        $outputType = $outputType ?? $this->outputType;
+        if ($outputType !== null) {
+            $params['response_format'] = ['type' => 'json_object'];
+        }
+
+        $stream = $this->client->chat()->createStreamed($params);
+
+        foreach ($stream as $response) {
+            $delta = $response['choices'][0]['delta']['content'] ?? '';
+            if ($delta !== '') {
+                yield $delta;
+            }
+        }
     }
 
     /**

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -170,6 +170,17 @@ class Runner
         });
     }
 
+    /**
+     * Run the agent and yield streamed output chunks.
+     *
+     * @return iterable<int, string>
+     */
+    public function runStreamed(string $message): iterable
+    {
+        $toolDefs = array_values(array_filter($this->tools, fn($t) => !empty($t['schema'])));
+        yield from $this->agent->chatStreamed($message, $toolDefs, $this->outputType);
+    }
+
     protected function outputMatches(string $content): bool
     {
         $data = json_decode($content, true);

--- a/src/VoicePipeline.php
+++ b/src/VoicePipeline.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+
+namespace OpenAI\LaravelAgents;
+
+use OpenAI\Contracts\ClientContract;
+
+class VoicePipeline
+{
+    protected ClientContract $client;
+    protected Agent $agent;
+
+    public function __construct(ClientContract $client, Agent $agent)
+    {
+        $this->client = $client;
+        $this->agent = $agent;
+    }
+
+    public function transcribe(string $file, array $options = []): string
+    {
+        $params = array_merge([
+            'model' => 'whisper-1',
+            'file' => fopen($file, 'r'),
+            'response_format' => 'text',
+        ], $options);
+
+        $response = $this->client->audio()->transcribe($params);
+        return (string) $response;
+    }
+
+    public function speak(string $text, array $options = []): string
+    {
+        return $this->agent->speak($text, $options);
+    }
+
+    public function run(string $file, array $options = []): string
+    {
+        $text = $this->transcribe($file, $options['transcribe'] ?? []);
+        $reply = $this->agent->chat($text);
+        return $this->speak($reply, $options['speak'] ?? []);
+    }
+}

--- a/tests/AgentCloneTest.php
+++ b/tests/AgentCloneTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use OpenAI\Contracts\ClientContract;
+use OpenAI\Contracts\ChatContract;
+use OpenAI\LaravelAgents\Agent;
+use PHPUnit\Framework\TestCase;
+
+class AgentCloneTest extends TestCase
+{
+    public function test_clone_copies_state_and_overrides()
+    {
+        $chat = $this->createMock(ChatContract::class);
+        $client = $this->createMock(ClientContract::class);
+        $client->method('chat')->willReturn($chat);
+
+        $agent = new Agent($client, ['temperature' => 0.5], 'sys', null, ['foo' => 'bar']);
+        $clone = $agent->clone(['temperature' => 1.0], 'new');
+
+        $this->assertInstanceOf(Agent::class, $clone);
+        $this->assertNotSame($agent, $clone);
+        $this->assertSame(['foo' => 'bar'], $clone->getContext());
+
+        $chat->expects($this->once())->method('create')->willReturn(['choices' => [['message' => ['content' => 'ok']]]]);
+        $result = $clone->chat('hi');
+        $this->assertSame('ok', $result);
+    }
+}

--- a/tests/RunnerStreamedTest.php
+++ b/tests/RunnerStreamedTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use OpenAI\Contracts\ClientContract;
+use OpenAI\Contracts\ChatContract;
+use OpenAI\LaravelAgents\Agent;
+use OpenAI\LaravelAgents\Runner;
+use PHPUnit\Framework\TestCase;
+
+class RunnerStreamedTest extends TestCase
+{
+    public function test_run_streamed_yields_chunks()
+    {
+        $stream = new ArrayIterator([
+            ['choices' => [['delta' => ['content' => 'a']]]],
+            ['choices' => [['delta' => ['content' => 'b']]]],
+        ]);
+
+        $chat = $this->createMock(ChatContract::class);
+        $chat->expects($this->once())
+            ->method('createStreamed')
+            ->willReturn($stream);
+
+        $client = $this->createMock(ClientContract::class);
+        $client->method('chat')->willReturn($chat);
+
+        $agent = new Agent($client);
+        $runner = new Runner($agent, 1);
+
+        $chunks = iterator_to_array($runner->runStreamed('hi'));
+        $this->assertSame(['a', 'b'], $chunks);
+    }
+}

--- a/tests/VoicePipelineTest.php
+++ b/tests/VoicePipelineTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use OpenAI\Contracts\AudioContract;
+use OpenAI\Contracts\ClientContract;
+use OpenAI\Contracts\ChatContract;
+use OpenAI\LaravelAgents\Agent;
+use OpenAI\LaravelAgents\VoicePipeline;
+use PHPUnit\Framework\TestCase;
+
+class VoicePipelineTest extends TestCase
+{
+    public function test_run_transcribes_and_speaks()
+    {
+        $audio = $this->createMock(AudioContract::class);
+        $audio->expects($this->once())
+            ->method('transcribe')
+            ->willReturn('hello');
+        $audio->expects($this->once())
+            ->method('speech')
+            ->willReturn('audio-data');
+
+        $chat = $this->createMock(ChatContract::class);
+        $chat->expects($this->once())
+            ->method('create')
+            ->willReturn(['choices' => [['message' => ['content' => 'reply']]]]);
+
+        $client = $this->createMock(ClientContract::class);
+        $client->method('audio')->willReturn($audio);
+        $client->method('chat')->willReturn($chat);
+
+        $agent = new Agent($client);
+        $pipeline = new VoicePipeline($client, $agent);
+
+        $result = $pipeline->run(__FILE__);
+        $this->assertSame('audio-data', $result);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -3,10 +3,12 @@
 namespace OpenAI\Contracts {
     interface ChatContract {
         public function create(array $parameters);
+        public function createStreamed(array $parameters);
     }
 
     interface AudioContract {
         public function speech(array $parameters);
+        public function transcribe(array $parameters);
     }
 
     interface ClientContract {
@@ -25,4 +27,5 @@ namespace {
     require_once __DIR__ . '/../src/Guardrails/InputGuardrail.php';
     require_once __DIR__ . '/../src/Guardrails/OutputGuardrail.php';
     require_once __DIR__ . '/../src/Tracing/Tracing.php';
+    require_once __DIR__ . '/../src/VoicePipeline.php';
 }


### PR DESCRIPTION
## Summary
- add context and cloning to `Agent`
- implement streamed chat support and runner wrapper
- introduce `VoicePipeline` for audio workflows
- document streaming and voice pipeline features
- test new functionality

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_b_68533e578fa0832798cdf5454eb821f3