### PR TITLE
Update package name references

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This package provides a lightweight integration of the [OpenAI PHP client](https
 ## Installation
 
 ```bash
-composer require openai/laravel-agents
+composer require aerobit/laravel-openai-agents
 ```
 
 Publish the configuration file:

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "aerobit/laravel-openai-agents",
-    "description": "OpenAI Agents SDK for Laravel",
+    "description": "Laravel OpenAI Agents SDK",
     "type": "library",
     "license": "MIT",
     "require": {
@@ -25,7 +25,7 @@
     "authors": [
         {
             "name": "Edgar Escudero",
-            "company": "aerobit.com"
+            "email": "edgar@aerobit.com"
         }
     ],
     "scripts": {

--- a/docs/guia.html
+++ b/docs/guia.html
@@ -2,7 +2,7 @@
 <html lang="es">
 <head>
     <meta charset="UTF-8">
-    <title>Guía del Package Laravel Agents</title>
+    <title>Guía del Package Laravel OpenAI Agents</title>
     <style>
         body { font-family: Arial, sans-serif; line-height: 1.6; padding: 20px; }
         pre { background: #f4f4f4; padding: 10px; overflow-x: auto; }
@@ -15,7 +15,7 @@
 <body>
     <h1>OpenAI Agents para Laravel</h1>
     <p>
-        Esta página explica los conceptos teóricos, la implementación en código y diversos casos de uso del paquete <code>openai/laravel-agents</code>.
+        Esta página explica los conceptos teóricos, la implementación en código y diversos casos de uso del paquete <code>aerobit/laravel-openai-agents</code>.
     </p>
 
     <h2>Conceptos teóricos</h2>
@@ -36,7 +36,7 @@
 
     <h2>Instalación</h2>
     <p>Para instalar el paquete, ejecute:</p>
-    <pre><code>composer require openai/laravel-agents
+    <pre><code>composer require aerobit/laravel-openai-agents
 php artisan vendor:publish --tag=config --provider="OpenAI\LaravelAgents\AgentServiceProvider"</code></pre>
 
     <h2>Ejemplo básico de uso</h2>


### PR DESCRIPTION
## Summary
- update composer package name in README and docs
- tweak docs title
- set composer description to `Laravel OpenAI Agents SDK`
- fix composer.json authors schema and run tests

## Testing
- `composer install --ignore-platform-reqs`
- `phpunit --configuration tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_b_68537b14df308327ad031a6274089f22