### PR TITLE
Rename package namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ This package provides a lightweight integration of the [OpenAI PHP client](https
 ## Installation
 
 ```bash
-composer require aerobit/laravel-openai-agents
+composer require aerobit/openai-agents
 ```
 
 Publish the configuration file:
 
 ```bash
-php artisan vendor:publish --tag=config --provider="OpenAI\\LaravelAgents\\AgentServiceProvider"
+php artisan vendor:publish --tag=config --provider="Aerobit\\OpenaiAgents\\AgentServiceProvider"
 ```
 
 Set your `OPENAI_API_KEY` in the environment file or edit `config/agents.php`.
@@ -34,7 +34,7 @@ php artisan agent:chat "Hello" --system="You are helpful" --max-turns=3
 You can also resolve the `AgentManager` service from the container to create agents programmatically.
 
 ```php
-use OpenAI\LaravelAgents\AgentManager;
+use Aerobit\OpenaiAgents\AgentManager;
 
 $manager = app(AgentManager::class);
 $response = $manager->agent()->chat('Hello world');
@@ -62,7 +62,7 @@ file_put_contents('output.mp3', $audio);
 You can optionally provide a system prompt when constructing the agent:
 
 ```php
-use OpenAI\LaravelAgents\Agent;
+use Aerobit\OpenaiAgents\Agent;
 use OpenAI\Client as OpenAIClient;
 
 $client = OpenAIClient::factory()->withApiKey(env('OPENAI_API_KEY'))->make();
@@ -74,7 +74,7 @@ agent returns a final response or a turn limit is reached. Tools and basic hando
 can be registered on the runner:
 
 ```php
-use OpenAI\LaravelAgents\Runner;
+use Aerobit\OpenaiAgents\Runner;
 
 $runner = new Runner($agent, maxTurns: 3);
 $runner->registerTool('echo', fn($text) => $text);
@@ -146,7 +146,7 @@ return [
         'enabled' => true,
         'processors' => [
             fn(array $record) => logger()->info('agent trace', $record),
-            new \OpenAI\LaravelAgents\Tracing\HttpProcessor('https://example.com/trace'),
+            new \Aerobit\OpenaiAgents\Tracing\HttpProcessor('https://example.com/trace'),
         ],
     ],
 ];
@@ -161,9 +161,9 @@ Guardrails let you validate input and output during a run. They can transform
 the content or throw an exception to stop execution.
 
 ```php
-use OpenAI\LaravelAgents\Guardrails\InputGuardrail;
-use OpenAI\LaravelAgents\Guardrails\OutputGuardrail;
-use OpenAI\LaravelAgents\Guardrails\OutputGuardrailException;
+use Aerobit\OpenaiAgents\Guardrails\InputGuardrail;
+use Aerobit\OpenaiAgents\Guardrails\OutputGuardrail;
+use Aerobit\OpenaiAgents\Guardrails\OutputGuardrailException;
 
 $runner->addInputGuardrail(new class extends InputGuardrail {
     public function validate(string $content): string

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "aerobit/laravel-openai-agents",
+    "name": "aerobit/openai-agents",
     "description": "Laravel OpenAI Agents SDK",
     "type": "library",
     "license": "MIT",
@@ -12,13 +12,13 @@
     },
     "autoload": {
         "psr-4": {
-            "OpenAI\\LaravelAgents\\": "src/"
+            "Aerobit\\OpenaiAgents\\": "src/"
         }
     },
     "extra": {
         "laravel": {
             "providers": [
-                "OpenAI\\LaravelAgents\\AgentServiceProvider"
+                "Aerobit\\OpenaiAgents\\AgentServiceProvider"
             ]
         }
     },

--- a/docs/guia.html
+++ b/docs/guia.html
@@ -15,7 +15,7 @@
 <body>
     <h1>OpenAI Agents para Laravel</h1>
     <p>
-        Esta página explica los conceptos teóricos, la implementación en código y diversos casos de uso del paquete <code>aerobit/laravel-openai-agents</code>.
+        Esta página explica los conceptos teóricos, la implementación en código y diversos casos de uso del paquete <code>aerobit/openai-agents</code>.
     </p>
 
     <h2>Conceptos teóricos</h2>
@@ -36,12 +36,12 @@
 
     <h2>Instalación</h2>
     <p>Para instalar el paquete, ejecute:</p>
-    <pre><code>composer require aerobit/laravel-openai-agents
-php artisan vendor:publish --tag=config --provider="OpenAI\LaravelAgents\AgentServiceProvider"</code></pre>
+    <pre><code>composer require aerobit/openai-agents
+php artisan vendor:publish --tag=config --provider="Aerobit\OpenaiAgents\AgentServiceProvider"</code></pre>
 
     <h2>Ejemplo básico de uso</h2>
     <pre><code>&lt;?php
-use OpenAI\LaravelAgents\AgentManager;
+use Aerobit\OpenaiAgents\AgentManager;
 
 $manager = app(AgentManager::class);
 $reply = $manager-&gt;agent()-&gt;chat('Hola mundo');

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace OpenAI\LaravelAgents;
+namespace Aerobit\OpenaiAgents;
 
 use OpenAI\Contracts\ClientContract;
 use OpenAI\Contracts\AudioContract;

--- a/src/AgentManager.php
+++ b/src/AgentManager.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace OpenAI\LaravelAgents;
+namespace Aerobit\OpenaiAgents;
 
 use OpenAI\Client as OpenAIClient;
 

--- a/src/AgentServiceProvider.php
+++ b/src/AgentServiceProvider.php
@@ -1,10 +1,10 @@
 <?php
 declare(strict_types=1);
 
-namespace OpenAI\LaravelAgents;
+namespace Aerobit\OpenaiAgents;
 
 use Illuminate\Support\ServiceProvider;
-use OpenAI\LaravelAgents\Tracing\Tracing;
+use Aerobit\OpenaiAgents\Tracing\Tracing;
 
 class AgentServiceProvider extends ServiceProvider
 {

--- a/src/Commands/ChatAgent.php
+++ b/src/Commands/ChatAgent.php
@@ -1,10 +1,10 @@
 <?php
 declare(strict_types=1);
 
-namespace OpenAI\LaravelAgents\Commands;
+namespace Aerobit\OpenaiAgents\Commands;
 
 use Illuminate\Console\Command;
-use OpenAI\LaravelAgents\AgentManager;
+use Aerobit\OpenaiAgents\AgentManager;
 
 class ChatAgent extends Command
 {
@@ -33,7 +33,7 @@ class ChatAgent extends Command
             };
         }
 
-        $runner = new \OpenAI\LaravelAgents\Runner($agent, $max, $tracer);
+        $runner = new \Aerobit\OpenaiAgents\Runner($agent, $max, $tracer);
 
         $response = $runner->run($message);
 

--- a/src/Guardrails/GuardrailException.php
+++ b/src/Guardrails/GuardrailException.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace OpenAI\LaravelAgents\Guardrails;
+namespace Aerobit\OpenaiAgents\Guardrails;
 
 use Exception;
 

--- a/src/Guardrails/InputGuardrail.php
+++ b/src/Guardrails/InputGuardrail.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace OpenAI\LaravelAgents\Guardrails;
+namespace Aerobit\OpenaiAgents\Guardrails;
 
 abstract class InputGuardrail
 {

--- a/src/Guardrails/InputGuardrailException.php
+++ b/src/Guardrails/InputGuardrailException.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace OpenAI\LaravelAgents\Guardrails;
+namespace Aerobit\OpenaiAgents\Guardrails;
 
 class InputGuardrailException extends GuardrailException
 {

--- a/src/Guardrails/OutputGuardrail.php
+++ b/src/Guardrails/OutputGuardrail.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace OpenAI\LaravelAgents\Guardrails;
+namespace Aerobit\OpenaiAgents\Guardrails;
 
 abstract class OutputGuardrail
 {

--- a/src/Guardrails/OutputGuardrailException.php
+++ b/src/Guardrails/OutputGuardrailException.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace OpenAI\LaravelAgents\Guardrails;
+namespace Aerobit\OpenaiAgents\Guardrails;
 
 class OutputGuardrailException extends GuardrailException
 {

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -1,12 +1,12 @@
 <?php
 declare(strict_types=1);
 
-namespace OpenAI\LaravelAgents;
+namespace Aerobit\OpenaiAgents;
 
-use OpenAI\LaravelAgents\Guardrails\GuardrailException;
-use OpenAI\LaravelAgents\Guardrails\InputGuardrail;
-use OpenAI\LaravelAgents\Guardrails\OutputGuardrail;
-use OpenAI\LaravelAgents\Tracing\Tracing;
+use Aerobit\OpenaiAgents\Guardrails\GuardrailException;
+use Aerobit\OpenaiAgents\Guardrails\InputGuardrail;
+use Aerobit\OpenaiAgents\Guardrails\OutputGuardrail;
+use Aerobit\OpenaiAgents\Tracing\Tracing;
 
 class Runner
 {

--- a/src/Tracing/HttpProcessor.php
+++ b/src/Tracing/HttpProcessor.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace OpenAI\LaravelAgents\Tracing;
+namespace Aerobit\OpenaiAgents\Tracing;
 
 use Symfony\Component\HttpClient\HttpClient;
 

--- a/src/Tracing/Tracing.php
+++ b/src/Tracing/Tracing.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace OpenAI\LaravelAgents\Tracing;
+namespace Aerobit\OpenaiAgents\Tracing;
 
 class Tracing
 {

--- a/src/VoicePipeline.php
+++ b/src/VoicePipeline.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace OpenAI\LaravelAgents;
+namespace Aerobit\OpenaiAgents;
 
 use OpenAI\Contracts\ClientContract;
 

--- a/tests/AgentChatTest.php
+++ b/tests/AgentChatTest.php
@@ -3,7 +3,7 @@
 use OpenAI\Contracts\ClientContract;
 use OpenAI\Contracts\ChatContract;
 use OpenAI\Contracts\AudioContract;
-use OpenAI\LaravelAgents\Agent;
+use Aerobit\OpenaiAgents\Agent;
 use PHPUnit\Framework\TestCase;
 
 class AgentChatTest extends TestCase

--- a/tests/AgentCloneTest.php
+++ b/tests/AgentCloneTest.php
@@ -2,7 +2,7 @@
 
 use OpenAI\Contracts\ClientContract;
 use OpenAI\Contracts\ChatContract;
-use OpenAI\LaravelAgents\Agent;
+use Aerobit\OpenaiAgents\Agent;
 use PHPUnit\Framework\TestCase;
 
 class AgentCloneTest extends TestCase

--- a/tests/AgentManagerTest.php
+++ b/tests/AgentManagerTest.php
@@ -14,7 +14,7 @@ namespace {
 use OpenAI\Contracts\ChatContract;
 use OpenAI\Contracts\AudioContract;
 use OpenAI\Contracts\ClientContract;
-use OpenAI\LaravelAgents\AgentManager;
+use Aerobit\OpenaiAgents\AgentManager;
 use PHPUnit\Framework\TestCase;
 
 class AgentManagerTest extends TestCase

--- a/tests/GuardrailTest.php
+++ b/tests/GuardrailTest.php
@@ -2,12 +2,12 @@
 
 use OpenAI\Contracts\ChatContract;
 use OpenAI\Contracts\ClientContract;
-use OpenAI\LaravelAgents\Agent;
-use OpenAI\LaravelAgents\Runner;
-use OpenAI\LaravelAgents\Guardrails\InputGuardrail;
-use OpenAI\LaravelAgents\Guardrails\OutputGuardrail;
-use OpenAI\LaravelAgents\Guardrails\OutputGuardrailException;
-use OpenAI\LaravelAgents\Guardrails\InputGuardrailException;
+use Aerobit\OpenaiAgents\Agent;
+use Aerobit\OpenaiAgents\Runner;
+use Aerobit\OpenaiAgents\Guardrails\InputGuardrail;
+use Aerobit\OpenaiAgents\Guardrails\OutputGuardrail;
+use Aerobit\OpenaiAgents\Guardrails\OutputGuardrailException;
+use Aerobit\OpenaiAgents\Guardrails\InputGuardrailException;
 use PHPUnit\Framework\TestCase;
 
 class GuardrailTest extends TestCase

--- a/tests/RunnerStreamedTest.php
+++ b/tests/RunnerStreamedTest.php
@@ -2,8 +2,8 @@
 
 use OpenAI\Contracts\ClientContract;
 use OpenAI\Contracts\ChatContract;
-use OpenAI\LaravelAgents\Agent;
-use OpenAI\LaravelAgents\Runner;
+use Aerobit\OpenaiAgents\Agent;
+use Aerobit\OpenaiAgents\Runner;
 use PHPUnit\Framework\TestCase;
 
 class RunnerStreamedTest extends TestCase

--- a/tests/RunnerTest.php
+++ b/tests/RunnerTest.php
@@ -2,8 +2,8 @@
 
 use OpenAI\Contracts\ClientContract;
 use OpenAI\Contracts\ChatContract;
-use OpenAI\LaravelAgents\Agent;
-use OpenAI\LaravelAgents\Runner;
+use Aerobit\OpenaiAgents\Agent;
+use Aerobit\OpenaiAgents\Runner;
 use PHPUnit\Framework\TestCase;
 
 class RunnerTest extends TestCase

--- a/tests/TracingTest.php
+++ b/tests/TracingTest.php
@@ -2,9 +2,9 @@
 
 use OpenAI\Contracts\ChatContract;
 use OpenAI\Contracts\ClientContract;
-use OpenAI\LaravelAgents\Agent;
-use OpenAI\LaravelAgents\Runner;
-use OpenAI\LaravelAgents\Tracing\Tracing;
+use Aerobit\OpenaiAgents\Agent;
+use Aerobit\OpenaiAgents\Runner;
+use Aerobit\OpenaiAgents\Tracing\Tracing;
 use PHPUnit\Framework\TestCase;
 
 class TracingTest extends TestCase

--- a/tests/VoicePipelineTest.php
+++ b/tests/VoicePipelineTest.php
@@ -3,8 +3,8 @@
 use OpenAI\Contracts\AudioContract;
 use OpenAI\Contracts\ClientContract;
 use OpenAI\Contracts\ChatContract;
-use OpenAI\LaravelAgents\Agent;
-use OpenAI\LaravelAgents\VoicePipeline;
+use Aerobit\OpenaiAgents\Agent;
+use Aerobit\OpenaiAgents\VoicePipeline;
 use PHPUnit\Framework\TestCase;
 
 class VoicePipelineTest extends TestCase


### PR DESCRIPTION
## Summary
- rename package to `aerobit/openai-agents`
- update composer autoload namespace
- switch PHP namespaces to `Aerobit\OpenaiAgents`
- update README and docs

## Testing
- `composer dump-autoload`
- `composer install` *(fails: requires php ^8.4)*

------
https://chatgpt.com/codex/tasks/task_b_68537f3d0d2c8327a5d252c79f8ea2e7