### PR TITLE
Switch to OpenAI\OpenAI factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ You can optionally provide a system prompt when constructing the agent:
 
 ```php
 use Aerobit\OpenaiAgents\Agent;
-use OpenAI\Client as OpenAIClient;
+use OpenAI\OpenAI;
 
-$client = OpenAIClient::factory()->withApiKey(env('OPENAI_API_KEY'))->make();
+$client = OpenAI::factory()->withApiKey(env('OPENAI_API_KEY'))->make();
 $agent = new Agent($client, [], 'You are a helpful assistant.');
 ```
 

--- a/src/AgentManager.php
+++ b/src/AgentManager.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Aerobit\OpenaiAgents;
 
-use OpenAI\Client as OpenAIClient;
+use OpenAI\OpenAI;
 
 class AgentManager
 {
@@ -27,7 +27,7 @@ class AgentManager
     {
         $options = array_replace_recursive($this->config['default'] ?? [], $options);
 
-        $client = OpenAIClient::factory()->withApiKey($this->config['api_key'])->make();
+        $client = OpenAI::factory()->withApiKey($this->config['api_key'])->make();
 
         return new Agent($client, $options, $systemPrompt);
     }

--- a/tests/AgentManagerTest.php
+++ b/tests/AgentManagerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 namespace OpenAI {
-    class Client {
+    class OpenAI {
         public static $factory;
         public static function factory() {
             return static::$factory;
@@ -38,7 +38,7 @@ class AgentManagerTest extends TestCase
             public function audio(): AudioContract { throw new \Exception('audio'); }
         };
 
-        \OpenAI\Client::$factory = new class($client) {
+        \OpenAI\OpenAI::$factory = new class($client) {
             private $client;
             public function __construct($client) { $this->client = $client; }
             public function withApiKey($key) { return $this; }
@@ -80,7 +80,7 @@ class AgentManagerTest extends TestCase
             public function audio(): AudioContract { throw new \Exception('audio'); }
         };
 
-        \OpenAI\Client::$factory = new class($client) {
+        \OpenAI\OpenAI::$factory = new class($client) {
             private $client;
             public function __construct($client) { $this->client = $client; }
             public function withApiKey($key) { return $this; }


### PR DESCRIPTION
## Summary
- use `OpenAI\OpenAI` to instantiate the client
- adjust README example to call `OpenAI::factory()`
- update AgentManager tests to stub `OpenAI\OpenAI` factory

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_b_685a0c8f565c8327a7dd1f7e87f93390